### PR TITLE
CCM-9979: Prevent deploy selecting wrong internal repo

### DIFF
--- a/.github/workflows/reusable_internal_repo_build.yaml
+++ b/.github/workflows/reusable_internal_repo_build.yaml
@@ -81,12 +81,20 @@ jobs:
           # Poll GitHub API to check the workflow status
           run_id=""
           for i in {1..12}; do
-            run_id=$(curl -s \
+            in_progress=$(curl -s \
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{ secrets.PR_TRIGGER_PAT }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              "https://api.github.com/repos/NHSDigital/nhs-notify-internal/actions/runs?event=workflow_dispatch&status=in_progress" \
-              | jq -r '.workflow_runs[0].id')
+              "https://api.github.com/repos/NHSDigital/nhs-notify-internal/actions/runs?event=workflow_dispatch&status=in_progress")
+
+            run_id=$(echo "$in_progress" | jq -r \
+              --arg env "${{ inputs.targetEnvironment }}" \
+              --arg component "${{ inputs.targetComponent }}" \
+              --arg repoName "nhs-notify-web-template-management" \
+              --arg releaseVersion "${{ inputs.releaseVersion }}" \
+              '.workflow_runs[]
+                | select(.name | contains($env) and contains($component) and contains($repoName) and contains($releaseVersion))
+                | .id' | head -n 1)
 
             if [[ -n "$run_id" && "$run_id" != null ]]; then
               echo "Found workflow run with ID: $run_id"

--- a/.github/workflows/reusable_internal_repo_build.yaml
+++ b/.github/workflows/reusable_internal_repo_build.yaml
@@ -90,7 +90,7 @@ jobs:
             run_id=$(echo "$in_progress" | jq -r \
               --arg env "${{ inputs.targetEnvironment }}" \
               --arg component "${{ inputs.targetComponent }}" \
-              --arg repoName "nhs-notify-web-template-management" \
+              --arg repoName "nhs-notify-observability" \
               --arg releaseVersion "${{ inputs.releaseVersion }}" \
               '.workflow_runs[]
                 | select(.name | contains($env) and contains($component) and contains($repoName) and contains($releaseVersion))


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

More specific selection of remote workflow running in internal.

Attempts to narrow branch down to env, component, repoName and releaseVersion.

```
            run_id=$(echo "$in_progress" | jq -r \
              --arg env "${{ inputs.targetEnvironment }}" \
              --arg component "${{ inputs.targetComponent }}" \
              --arg repoName "nhs-notify-observability" \
              --arg releaseVersion "${{ inputs.releaseVersion }}" \
              '.workflow_runs[]
                | select(.name | contains($env) and contains($component) and contains($repoName) and contains($releaseVersion))
                | .id' | head -n 1)
```

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
