### PR TITLE
CCM-10579: Temporary revert to current default datasources till webui cutover

### DIFF
--- a/infrastructure/terraform/components/obsconfig/dashboards/template-mgmt/template-mgmt.json
+++ b/infrastructure/terraform/components/obsconfig/dashboards/template-mgmt/template-mgmt.json
@@ -515,7 +515,7 @@
         {
           "id": "renameByRegex",
           "options": {
-            "regex": "nhs-.*-app-(.*)",
+            "regex": "nhs-notify-.*-app-(.*)",
             "renamePattern": "$1"
           }
         }
@@ -794,7 +794,7 @@
         {
           "id": "renameByRegex",
           "options": {
-            "regex": "nhs-.*-app-(.*)",
+            "regex": "nhs-notify-.*-app-(.*)",
             "renamePattern": "$1"
           }
         }
@@ -938,7 +938,7 @@
         {
           "id": "renameByRegex",
           "options": {
-            "regex": "nhs-.*-app-(.*)",
+            "regex": "nhs-notify-.*-app-(.*)",
             "renamePattern": "$1"
           }
         }
@@ -1397,7 +1397,7 @@
         {
           "id": "renameByRegex",
           "options": {
-            "regex": "nhs-.*-app-(.*)",
+            "regex": "nhs-notify-.*-app-(.*)",
             "renamePattern": "$1"
           }
         }
@@ -1511,7 +1511,7 @@
         {
           "id": "renameByRegex",
           "options": {
-            "regex": "nhs-.*-app-(.*)",
+            "regex": "nhs-notify-.*-app-(.*)",
             "renamePattern": "$1"
           }
         }
@@ -2532,7 +2532,7 @@
         {
           "id": "renameByRegex",
           "options": {
-            "regex": "nhs-.*-app-(.*)",
+            "regex": "nhs-notify-.*-app-(.*)",
             "renamePattern": "$1"
           }
         }
@@ -2569,8 +2569,8 @@
       {
         "current": {
           "selected": false,
-          "text": "nhs-main-app",
-          "value": "nhs-main-app"
+          "text": "nhs-notify-main-app",
+          "value": "nhs-notify-main-app"
         },
         "description": "",
         "hide": 2,
@@ -2581,11 +2581,11 @@
         "options": [
           {
             "selected": true,
-            "text": "nhs-main-app",
-            "value": "nhs-main-app"
+            "text": "nhs-notify-main-app",
+            "value": "nhs-notify-main-app"
           }
         ],
-        "query": "nhs-${env}-app",
+        "query": "nhs-notify-${env}-app",
         "skipUrlSync": false,
         "type": "custom"
       },
@@ -2604,15 +2604,15 @@
         "query": "cloudwatch",
         "queryValue": "",
         "refresh": 1,
-        "regex": ".*webui",
+        "regex": ".*template-mgmt",
         "skipUrlSync": false,
         "type": "datasource"
       },
       {
         "current": {
           "selected": false,
-          "text": "nhs-main-app-api",
-          "value": "nhs-main-app-api"
+          "text": "nhs-notify-main-app-api",
+          "value": "nhs-notify-main-app-api"
         },
         "hide": 2,
         "includeAll": false,
@@ -2622,8 +2622,8 @@
         "options": [
           {
             "selected": true,
-            "text": "nhs-main-app-api",
-            "value": "nhs-main-app-api"
+            "text": "nhs-notify-main-app-api",
+            "value": "nhs-notify-main-app-api"
           }
         ],
         "query": "${envCsi}-api",
@@ -2633,8 +2633,8 @@
       {
         "current": {
           "selected": false,
-          "text": "nhs-main-app-backup-vault",
-          "value": "nhs-main-app-backup-vault"
+          "text": "nhs-notify-main-app-backup-vault",
+          "value": "nhs-notify-main-app-backup-vault"
         },
         "hide": 2,
         "includeAll": false,
@@ -2644,8 +2644,8 @@
         "options": [
           {
             "selected": true,
-            "text": "nhs-main-app-backup-vault",
-            "value": "nhs-main-app-backup-vault"
+            "text": "nhs-notify-main-app-backup-vault",
+            "value": "nhs-notify-main-app-backup-vault"
           }
         ],
         "query": "${envCsi}-backup-vault",

--- a/infrastructure/terraform/components/obsconfig/dashboards/web-gateway/web-gateway-overview.json
+++ b/infrastructure/terraform/components/obsconfig/dashboards/web-gateway/web-gateway-overview.json
@@ -1684,10 +1684,10 @@
       {
         "current": {
           "selected": false,
-          "text": "nhs-main-cdn",
-          "value": "nhs-main-cdn"
+          "text": "nhs-notify-main-cdn",
+          "value": "nhs-notify-main-cdn"
         },
-        "description": "nhs-main-cdn",
+        "description": "nhs-notify-main-cdn",
         "hide": 2,
         "includeAll": false,
         "label": "Environment CSI Prefix",
@@ -1696,11 +1696,11 @@
         "options": [
           {
             "selected": true,
-            "text": "nhs-main-cdn",
-            "value": "nhs-main-cdn"
+            "text": "nhs-notify-main-cdn",
+            "value": "nhs-notify-main-cdn"
           }
         ],
-        "query": "nhs-${env}-cdn",
+        "query": "nhs-notify-${env}-cdn",
         "skipUrlSync": false,
         "type": "custom"
       },
@@ -1719,7 +1719,7 @@
         "query": "cloudwatch",
         "queryValue": "",
         "refresh": 1,
-        "regex": ".*webui",
+        "regex": ".*web-gateway",
         "skipUrlSync": false,
         "type": "datasource"
       },

--- a/infrastructure/terraform/components/obsconfig/dashboards/webauth/webauth.json
+++ b/infrastructure/terraform/components/obsconfig/dashboards/webauth/webauth.json
@@ -541,7 +541,7 @@
         {
           "id": "renameByRegex",
           "options": {
-            "regex": "nhs-.*-app-(.*)",
+            "regex": "nhs-notify-.*-app-(.*)",
             "renamePattern": "$1"
           }
         }
@@ -678,7 +678,7 @@
           "id": "filterFieldsByName",
           "options": {
             "include": {
-              "pattern": "Time|^nhs-${env}-[^\\s]+$"
+              "pattern": "Time|^nhs-notify-${env}-[^\\s]+$"
             }
           }
         },
@@ -973,7 +973,7 @@
           "id": "filterFieldsByName",
           "options": {
             "include": {
-              "pattern": "Time|^nhs-${env}-[^\\s]+$"
+              "pattern": "Time|^nhs-notify-${env}-[^\\s]+$"
             }
           }
         },
@@ -1710,8 +1710,8 @@
       {
         "current": {
           "selected": false,
-          "text": "nhs-main",
-          "value": "nhs-main"
+          "text": "nhs-notify-main",
+          "value": "nhs-notify-main"
         },
         "description": "",
         "hide": 2,
@@ -1722,11 +1722,11 @@
         "options": [
           {
             "selected": true,
-            "text": "nhs-main",
-            "value": "nhs-main"
+            "text": "nhs-notify-main",
+            "value": "nhs-notify-main"
           }
         ],
-        "query": "nhs-${env}",
+        "query": "nhs-notify-${env}",
         "skipUrlSync": false,
         "type": "custom"
       },
@@ -1745,15 +1745,15 @@
         "query": "cloudwatch",
         "queryValue": "",
         "refresh": 1,
-        "regex": ".*webui",
+        "regex": ".*iam",
         "skipUrlSync": false,
         "type": "datasource"
       },
       {
         "current": {
           "selected": false,
-          "text": "nhs-main-api",
-          "value": "nhs-main-api"
+          "text": "nhs-notify-main-api",
+          "value": "nhs-notify-main-api"
         },
         "hide": 2,
         "includeAll": false,
@@ -1763,8 +1763,8 @@
         "options": [
           {
             "selected": true,
-            "text": "nhs-main-api",
-            "value": "nhs-main-api"
+            "text": "nhs-notify-main-api",
+            "value": "nhs-notify-main-api"
           }
         ],
         "query": "${envCsi}-api",
@@ -1774,8 +1774,8 @@
       {
         "current": {
           "selected": false,
-          "text": "nhs-main-backup-vault",
-          "value": "nhs-main-backup-vault"
+          "text": "nhs-notify-main-backup-vault",
+          "value": "nhs-notify-main-backup-vault"
         },
         "hide": 2,
         "includeAll": false,
@@ -1785,8 +1785,8 @@
         "options": [
           {
             "selected": true,
-            "text": "nhs-main-backup-vault",
-            "value": "nhs-main-backup-vault"
+            "text": "nhs-notify-main-backup-vault",
+            "value": "nhs-notify-main-backup-vault"
           }
         ],
         "query": "${envCsi}-backup-vault",
@@ -1816,8 +1816,8 @@
       {
         "current": {
           "selected": false,
-          "text": "nhs-main-app",
-          "value": "nhs-main-app"
+          "text": "nhs-notify-main-app",
+          "value": "nhs-notify-main-app"
         },
         "hide": 2,
         "includeAll": false,
@@ -1827,8 +1827,8 @@
         "options": [
           {
             "selected": true,
-            "text": "nhs-main-app",
-            "value": "nhs-main-app"
+            "text": "nhs-notify-main-app",
+            "value": "nhs-notify-main-app"
           }
         ],
         "query": "${envCsi}-app",
@@ -1838,8 +1838,8 @@
       {
         "current": {
           "selected": false,
-          "text": "nhs-main-app-api",
-          "value": "nhs-main-app-api"
+          "text": "nhs-notify-main-app-api",
+          "value": "nhs-notify-main-app-api"
         },
         "description": "The API isn't in the API component for... reasons",
         "hide": 2,
@@ -1850,8 +1850,8 @@
         "options": [
           {
             "selected": true,
-            "text": "nhs-main-app-api",
-            "value": "nhs-main-app-api"
+            "text": "nhs-notify-main-app-api",
+            "value": "nhs-notify-main-app-api"
           }
         ],
         "query": "${envCsi}-app-api",


### PR DESCRIPTION
## Description

Temporary revert to current default datasources till webui cutover is carried out in future sprint

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
