### PR TITLE
CCM-14499: Pin GitHub Actions to SHAs

### DIFF
--- a/.github/workflows/cicd-1-pull-request.yaml
+++ b/.github/workflows/cicd-1-pull-request.yaml
@@ -32,7 +32,8 @@ jobs:
       # skip_trivy_package: ${{ steps.skip_trivy.outputs.skip_trivy_package }}
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Set CI/CD variables"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: "Set CI/CD variables"
         id: variables
         run: |
           datetime=$(date -u +'%Y-%m-%dT%H:%M:%S%z')

--- a/.github/workflows/cicd-1-pull-request.yaml
+++ b/.github/workflows/cicd-1-pull-request.yaml
@@ -32,8 +32,7 @@ jobs:
       # skip_trivy_package: ${{ steps.skip_trivy.outputs.skip_trivy_package }}
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: "Set CI/CD variables"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Set CI/CD variables"
         id: variables
         run: |
           datetime=$(date -u +'%Y-%m-%dT%H:%M:%S%z')

--- a/.github/workflows/cicd-3-deploy.yaml
+++ b/.github/workflows/cicd-3-deploy.yaml
@@ -37,8 +37,7 @@ jobs:
       # tag: ${{ steps.variables.outputs.tag }}
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: "Set CI/CD variables"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Set CI/CD variables"
         id: variables
         run: |
           datetime=$(date -u +'%Y-%m-%dT%H:%M:%S%z')
@@ -70,8 +69,7 @@ jobs:
     needs: metadata
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: "Get version"
         id: get-asset-version
         shell: bash
@@ -110,6 +108,5 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
-        with:
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4        with:
           artifact_name: jekyll-docs-${{steps.get-asset-version.outputs.release_version}}

--- a/.github/workflows/cicd-3-deploy.yaml
+++ b/.github/workflows/cicd-3-deploy.yaml
@@ -37,7 +37,8 @@ jobs:
       # tag: ${{ steps.variables.outputs.tag }}
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Set CI/CD variables"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: "Set CI/CD variables"
         id: variables
         run: |
           datetime=$(date -u +'%Y-%m-%dT%H:%M:%S%z')
@@ -108,5 +109,6 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4        with:
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        with:
           artifact_name: jekyll-docs-${{steps.get-asset-version.outputs.release_version}}

--- a/.github/workflows/cicd-3-deploy.yaml
+++ b/.github/workflows/cicd-3-deploy.yaml
@@ -102,7 +102,7 @@ jobs:
         run: |
           gh release download ${{steps.get-asset-version.outputs.release_version}} -p jekyll-docs-*.tar --output artifact.tar
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: jekyll-docs-${{steps.get-asset-version.outputs.release_version}}
           path: artifact.tar

--- a/.github/workflows/manual-combine-dependabot-prs.yaml
+++ b/.github/workflows/manual-combine-dependabot-prs.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: combine-prs
         id: combine-prs
-        uses: github/combine-prs@e6d37110da1b512313419ba6992492dad622139f # v5.2.0        with:
+        uses: github/combine-prs@2909f404763c3177a456e052bdb7f2e85d3a7cb3 # v5.2.0        with:
           ci_required: false
           labels: dependencies
           pr_title: Combined Dependabot PRs

--- a/.github/workflows/manual-combine-dependabot-prs.yaml
+++ b/.github/workflows/manual-combine-dependabot-prs.yaml
@@ -15,8 +15,7 @@ jobs:
     steps:
       - name: combine-prs
         id: combine-prs
-        uses: github/combine-prs@v5.2.0
-        with:
+        uses: github/combine-prs@e6d37110da1b512313419ba6992492dad622139f # v5.2.0        with:
           ci_required: false
           labels: dependencies
           pr_title: Combined Dependabot PRs

--- a/.github/workflows/manual-combine-dependabot-prs.yaml
+++ b/.github/workflows/manual-combine-dependabot-prs.yaml
@@ -15,7 +15,8 @@ jobs:
     steps:
       - name: combine-prs
         id: combine-prs
-        uses: github/combine-prs@2909f404763c3177a456e052bdb7f2e85d3a7cb3 # v5.2.0        with:
+        uses: github/combine-prs@2909f404763c3177a456e052bdb7f2e85d3a7cb3 # v5.2.0
+        with:
           ci_required: false
           labels: dependencies
           pr_title: Combined Dependabot PRs

--- a/.github/workflows/pr_closed.yaml
+++ b/.github/workflows/pr_closed.yaml
@@ -48,8 +48,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Updating Main Environment
         env:
           APP_PEM_FILE: ${{ secrets.APP_PEM_FILE }}

--- a/.github/workflows/release_created.yaml
+++ b/.github/workflows/release_created.yaml
@@ -24,8 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Deploy Nonprod Environment
         env:
           APP_PEM_FILE: ${{ secrets.APP_PEM_FILE }}

--- a/.github/workflows/scheduled-repository-template-sync.yaml
+++ b/.github/workflows/scheduled-repository-template-sync.yaml
@@ -24,7 +24,8 @@ jobs:
 
     - name: Create Pull Request
       if: ${{ !env.ACT }}
-      uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8      with:
+      uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+      with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: Drift from template
         branch: scheduledTemplateRepositorySync

--- a/.github/workflows/scheduled-repository-template-sync.yaml
+++ b/.github/workflows/scheduled-repository-template-sync.yaml
@@ -16,8 +16,7 @@ jobs:
 
     steps:
     - name: Check out the repository
-      uses: actions/checkout@v4
-
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Sync repository template
       uses: NHSDigital/nhs-notify-shared-modules/.github/actions/sync-template-repo@3.0.0
       with:
@@ -25,8 +24,7 @@ jobs:
 
     - name: Create Pull Request
       if: ${{ !env.ACT }}
-      uses: peter-evans/create-pull-request@v7.0.8
-      with:
+      uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8      with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: Drift from template
         branch: scheduledTemplateRepositorySync

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -59,8 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@v5
-        with:
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5        with:
           name: SARIF file
           path: results.sarif
           retention-days: 5

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -59,7 +59,8 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5        with:
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        with:
           name: SARIF file
           path: results.sarif
           retention-days: 5

--- a/.github/workflows/stage-1-commit.yaml
+++ b/.github/workflows/stage-1-commit.yaml
@@ -44,7 +44,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4        with:
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
           fetch-depth: 0 # Full history is needed to scan all commits
       - name: "Scan secrets"
         uses: NHSDigital/nhs-notify-shared-modules/.github/actions/scan-secrets@3.0.0
@@ -54,7 +55,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4        with:
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
           fetch-depth: 0 # Full history is needed to compare branches
       - name: "Check file format"
         uses: NHSDigital/nhs-notify-shared-modules/.github/actions/check-file-format@3.0.0
@@ -64,7 +66,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4        with:
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
           fetch-depth: 0 # Full history is needed to compare branches
       - name: "Check Markdown format"
         uses: NHSDigital/nhs-notify-shared-modules/.github/actions/check-markdown-format@3.0.0
@@ -77,7 +80,8 @@ jobs:
         contents: write
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4        with:
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
           fetch-depth: 0 # Full history is needed to compare branches
       - name: "Check to see if Terraform Docs are up-to-date"
         run: |
@@ -97,7 +101,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4        with:
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
           fetch-depth: 0 # Full history is needed to compare branches
       - name: "Check English usage"
         uses: NHSDigital/nhs-notify-shared-modules/.github/actions/check-english-usage@3.0.0
@@ -107,7 +112,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4        with:
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
           fetch-depth: 0 # Full history is needed to compare branches
       - name: "Check TODO usage"
         uses: NHSDigital/nhs-notify-shared-modules/.github/actions/check-todo-usage@3.0.0
@@ -141,7 +147,8 @@ jobs:
     if: needs.detect-terraform-changes.outputs.terraform_changed == 'true'
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Setup ASDF"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: "Setup ASDF"
         uses: asdf-vm/actions/setup@1902764435ca0dd2f3388eea723a4f92a4eb8302
       - name: "Lint Terraform"
         uses: NHSDigital/nhs-notify-shared-modules/.github/actions/lint-terraform@3.0.0
@@ -184,7 +191,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Count lines of code"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: "Count lines of code"
         uses: NHSDigital/nhs-notify-shared-modules/.github/actions/create-lines-of-code-report@3.0.0
         with:
           build_datetime: "${{ inputs.build_datetime }}"
@@ -202,7 +210,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Scan dependencies"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: "Scan dependencies"
         uses: NHSDigital/nhs-notify-shared-modules/.github/actions/scan-dependencies@3.0.0
         with:
           build_datetime: "${{ inputs.build_datetime }}"

--- a/.github/workflows/stage-1-commit.yaml
+++ b/.github/workflows/stage-1-commit.yaml
@@ -44,8 +44,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-        with:
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4        with:
           fetch-depth: 0 # Full history is needed to scan all commits
       - name: "Scan secrets"
         uses: NHSDigital/nhs-notify-shared-modules/.github/actions/scan-secrets@3.0.0
@@ -55,8 +54,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-        with:
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4        with:
           fetch-depth: 0 # Full history is needed to compare branches
       - name: "Check file format"
         uses: NHSDigital/nhs-notify-shared-modules/.github/actions/check-file-format@3.0.0
@@ -66,8 +64,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-        with:
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4        with:
           fetch-depth: 0 # Full history is needed to compare branches
       - name: "Check Markdown format"
         uses: NHSDigital/nhs-notify-shared-modules/.github/actions/check-markdown-format@3.0.0
@@ -80,8 +77,7 @@ jobs:
         contents: write
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-        with:
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4        with:
           fetch-depth: 0 # Full history is needed to compare branches
       - name: "Check to see if Terraform Docs are up-to-date"
         run: |
@@ -101,8 +97,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-        with:
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4        with:
           fetch-depth: 0 # Full history is needed to compare branches
       - name: "Check English usage"
         uses: NHSDigital/nhs-notify-shared-modules/.github/actions/check-english-usage@3.0.0
@@ -112,8 +107,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-        with:
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4        with:
           fetch-depth: 0 # Full history is needed to compare branches
       - name: "Check TODO usage"
         uses: NHSDigital/nhs-notify-shared-modules/.github/actions/check-todo-usage@3.0.0
@@ -124,8 +118,7 @@ jobs:
       terraform_changed: ${{ steps.check.outputs.terraform_changed }}
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: "Check for Terraform changes"
         id: check
         run: |
@@ -148,8 +141,7 @@ jobs:
     if: needs.detect-terraform-changes.outputs.terraform_changed == 'true'
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: "Setup ASDF"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Setup ASDF"
         uses: asdf-vm/actions/setup@1902764435ca0dd2f3388eea723a4f92a4eb8302
       - name: "Lint Terraform"
         uses: NHSDigital/nhs-notify-shared-modules/.github/actions/lint-terraform@3.0.0
@@ -192,8 +184,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: "Count lines of code"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Count lines of code"
         uses: NHSDigital/nhs-notify-shared-modules/.github/actions/create-lines-of-code-report@3.0.0
         with:
           build_datetime: "${{ inputs.build_datetime }}"
@@ -211,8 +202,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: "Scan dependencies"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Scan dependencies"
         uses: NHSDigital/nhs-notify-shared-modules/.github/actions/scan-dependencies@3.0.0
         with:
           build_datetime: "${{ inputs.build_datetime }}"

--- a/.github/workflows/stage-1-commit.yaml
+++ b/.github/workflows/stage-1-commit.yaml
@@ -163,7 +163,7 @@ jobs:
   #  if: needs.detect-terraform-changes.outputs.terraform_changed == 'true'
   #  steps:
   #    - name: "Checkout code"
-  #      uses: actions/checkout@v4
+  #      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
   #    - name: "Setup ASDF"
   #      uses: asdf-vm/actions/setup@1902764435ca0dd2f3388eea723a4f92a4eb8302
   #    - name: "Trivy IaC Scan"
@@ -177,7 +177,7 @@ jobs:
   #  timeout-minutes: 10
   #  steps:
   #    - name: "Checkout code"
-  #      uses: actions/checkout@v4
+  #      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
   #    - name: "Setup ASDF"
   #      uses: asdf-vm/actions/setup@1902764435ca0dd2f3388eea723a4f92a4eb8302
   #    - name: "Trivy Package Scan"

--- a/.github/workflows/stage-2-test.yaml
+++ b/.github/workflows/stage-2-test.yaml
@@ -39,7 +39,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Run unit test suite"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: "Run unit test suite"
         run: |
           make test-unit
       - name: "Save the result of fast test suite"
@@ -51,7 +52,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Run linting"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: "Run linting"
         run: |
           make test-lint
       - name: "Save the linting result"
@@ -64,7 +66,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Run test coverage check"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: "Run test coverage check"
         run: |
           make test-coverage
       - name: "Save the coverage check result"
@@ -80,7 +83,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4        with:
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
           fetch-depth: 0 # Full history is needed to improving relevancy of reporting
       - name: "Perform static analysis"
         uses: NHSDigital/nhs-notify-shared-modules/.github/actions/perform-static-analysis@3.0.0

--- a/.github/workflows/stage-2-test.yaml
+++ b/.github/workflows/stage-2-test.yaml
@@ -39,8 +39,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: "Run unit test suite"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Run unit test suite"
         run: |
           make test-unit
       - name: "Save the result of fast test suite"
@@ -52,8 +51,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: "Run linting"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Run linting"
         run: |
           make test-lint
       - name: "Save the linting result"
@@ -66,8 +64,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: "Run test coverage check"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Run test coverage check"
         run: |
           make test-coverage
       - name: "Save the coverage check result"
@@ -83,8 +80,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-        with:
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4        with:
           fetch-depth: 0 # Full history is needed to improving relevancy of reporting
       - name: "Perform static analysis"
         uses: NHSDigital/nhs-notify-shared-modules/.github/actions/perform-static-analysis@3.0.0

--- a/.github/workflows/stage-3-build.yaml
+++ b/.github/workflows/stage-3-build.yaml
@@ -39,7 +39,8 @@ jobs:
     timeout-minutes: 3
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Build docs"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: "Build docs"
         uses: NHSDigital/nhs-notify-shared-modules/.github/actions/build-docs@3.0.0
         with:
           version: "${{ inputs.version }}"
@@ -49,7 +50,8 @@ jobs:
     timeout-minutes: 3
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Build artefact 1"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: "Build artefact 1"
         run: |
           echo "Building artefact 1 ..."
       - name: "Check artefact 1"
@@ -65,7 +67,8 @@ jobs:
     timeout-minutes: 3
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Build artefact n"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: "Build artefact n"
         run: |
           echo "Building artefact n ..."
       - name: "Check artefact n"

--- a/.github/workflows/stage-3-build.yaml
+++ b/.github/workflows/stage-3-build.yaml
@@ -39,8 +39,7 @@ jobs:
     timeout-minutes: 3
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: "Build docs"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Build docs"
         uses: NHSDigital/nhs-notify-shared-modules/.github/actions/build-docs@3.0.0
         with:
           version: "${{ inputs.version }}"
@@ -50,8 +49,7 @@ jobs:
     timeout-minutes: 3
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: "Build artefact 1"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Build artefact 1"
         run: |
           echo "Building artefact 1 ..."
       - name: "Check artefact 1"
@@ -67,8 +65,7 @@ jobs:
     timeout-minutes: 3
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: "Build artefact n"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Build artefact n"
         run: |
           echo "Building artefact n ..."
       - name: "Check artefact n"

--- a/.github/workflows/stage-4-acceptance.yaml
+++ b/.github/workflows/stage-4-acceptance.yaml
@@ -43,8 +43,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: "Create infractructure"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Create infractructure"
         run: |
           echo "Creating infractructure..."
       - name: "Update database"
@@ -60,8 +59,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: "Run contract test"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Run contract test"
         run: |
           make test-contract
       - name: "Save result"
@@ -74,8 +72,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: "Run security test"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Run security test"
         run: |
           make test-security
       - name: "Save result"
@@ -88,8 +85,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: "Run UI test"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Run UI test"
         run: |
           make test-ui
       - name: "Save result"
@@ -102,8 +98,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: "Run UI performance test"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Run UI performance test"
         run: |
           make test-ui-performance
       - name: "Save result"
@@ -116,8 +111,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: "Run integration test"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Run integration test"
         run: |
           make test-integration
       - name: "Save result"
@@ -130,8 +124,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: "Run accessibility test"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Run accessibility test"
         run: |
           make test-accessibility
       - name: "Save result"
@@ -144,8 +137,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: "Run load tests"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Run load tests"
         run: |
           make test-load
       - name: "Save result"
@@ -168,7 +160,6 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: "Tear down environment"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Tear down environment"
         run: |
           echo "Tearing down environment..."

--- a/.github/workflows/stage-4-acceptance.yaml
+++ b/.github/workflows/stage-4-acceptance.yaml
@@ -43,7 +43,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Create infractructure"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: "Create infractructure"
         run: |
           echo "Creating infractructure..."
       - name: "Update database"
@@ -59,7 +60,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Run contract test"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: "Run contract test"
         run: |
           make test-contract
       - name: "Save result"
@@ -72,7 +74,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Run security test"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: "Run security test"
         run: |
           make test-security
       - name: "Save result"
@@ -85,7 +88,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Run UI test"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: "Run UI test"
         run: |
           make test-ui
       - name: "Save result"
@@ -98,7 +102,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Run UI performance test"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: "Run UI performance test"
         run: |
           make test-ui-performance
       - name: "Save result"
@@ -111,7 +116,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Run integration test"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: "Run integration test"
         run: |
           make test-integration
       - name: "Save result"
@@ -124,7 +130,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Run accessibility test"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: "Run accessibility test"
         run: |
           make test-accessibility
       - name: "Save result"
@@ -137,7 +144,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Run load tests"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: "Run load tests"
         run: |
           make test-load
       - name: "Save result"
@@ -160,6 +168,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4      - name: "Tear down environment"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: "Tear down environment"
         run: |
           echo "Tearing down environment..."


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Following the recent barrage of supply chain threats and especially https://www.wiz.io/blog/new-github-action-supply-chain-attack-reviewdog-action-setup its now recommended all 3rd party actions be referenced using SHA rather than a tag as tags are not immutable but the commits are.


## Type of changes

The following actions were pinned by SHA

- actions/checkout@v4
- actions/deploy-pages@v4
- actions/upload-artifact@v5
- github/combine-prs@v5.2.0
- peter-evans/create-pull-request@v7.0.8

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming
<!-- - [ ] If I have used the 'skip-trivy-package' label I have done so responsibly and in the knowledge that this is being fixed as part of a separate ticket/PR. -->

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
